### PR TITLE
Add Retargetable Analysis of Machine Code PhD thesis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A curated list of awesome decompilation resources and projects.
 
  * [Static Single Assignment for Decompilation](https://yurichev.com/mirrors/vanEmmerik_ssa.pdf)
 
+* [Retargetable Analysis of Machine Code](https://dspace.vutbr.cz/bitstream/handle/11012/63279/482.pdf)
+
  * [A Human-Centric Approach For Binary Code Decompilation](http://hss.ulb.uni-bonn.de/2018/5004/5004.pdf)
 
 ## Projects


### PR DESCRIPTION
This paper is related to the RetDec decompiler [1,2].

`[1]`: https://retdec.com/
`[2]`: https://github.com/avast-tl/retdec

Added to list of papers, sorting by release date.